### PR TITLE
Revert credit removing

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Pull requests are more than welcome. You must follow the PSR coding standards.
 ## Credits
 
 - [Denis Duliçi](https://github.com/denisdulici)
+- [Nicolas Widart](https://github.com/nwidart)
 - [All Contributors](../../contributors)
 
 ## License


### PR DESCRIPTION
Hi, 
As this project is almost a basic copy/paste of https://github.com/nWidart/laravel-modules with replacement of namespaces, this commit revert [the one](https://github.com/akaunting/module/commit/712b6e291f770d2027d9a582ea4d7914a45967d7) where you removed @nwidart from the credits.

(PS: I think what you were looking for here is called "fork" 🙄)

Thanks.